### PR TITLE
Security hardening: input validation and SECURITY.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
 PageSnapshot.html
 .vscode
-temp__pycache__/
+__pycache__/
 *.pyc
+*.pyo
+
+# Secrets / credentials
+.env
+.env.*
+*.key
+*.pem
+secrets.json
+config.local.*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest commit on `master` is actively maintained.
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability in this project, please **do not open a public issue**.
+
+Instead, report it privately via [GitHub's private vulnerability reporting](https://github.com/MichalJes/ETS2_RadioFix/security/advisories/new).
+
+Please include:
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+You can expect an acknowledgement within 7 days.
+
+## Scope
+
+This project scrapes radio station data from the [Truck Simulator Fandom wiki](https://truck-simulator.fandom.com/wiki/Radio_Stations) and writes it into a game configuration file (`live_streams.sii`). Security considerations include:
+
+- **URL injection** — malicious URLs committed to the wiki could end up in the output file. The scraper validates all URLs (scheme allowlist, length cap, format check) before writing them.
+- **Field injection** — pipe characters and quotes are stripped from station names and genres to prevent breaking the `.sii` format.

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,7 +1,16 @@
 import re
 import json
 import urllib.request
+import urllib.parse
 from dataclasses import dataclass
+
+# Allowed URL schemes and a hard cap on field lengths to prevent injecting
+# malformed entries into the .sii file from a compromised wiki page.
+_ALLOWED_SCHEMES = {"http", "https"}
+_MAX_URL_LEN = 512
+_MAX_FIELD_LEN = 128
+# Characters that would break the .sii pipe-delimited format
+_SII_FORBIDDEN = re.compile(r'[|"\n\r]')
 
 FANDOM_API = (
     "https://truck-simulator.fandom.com/api.php"
@@ -58,6 +67,31 @@ def _clean(text: str) -> str:
 def _extract_url(text: str) -> str | None:
     m = re.search(r"https?://\S+", text)
     return m.group(0).rstrip(".,;)") if m else None
+
+
+def _validate_url(url: str) -> str | None:
+    """Return the URL if safe to write into .sii, else None."""
+    if len(url) > _MAX_URL_LEN:
+        return None
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except Exception:
+        return None
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        return None
+    if not parsed.netloc:
+        return None
+    # Strip any fragment (e.g. #AddedByRaf_Salvado) — not valid in stream URLs
+    url = urllib.parse.urlunparse(parsed._replace(fragment=""))
+    if _SII_FORBIDDEN.search(url):
+        return None
+    return url
+
+
+def _sanitise_field(value: str) -> str:
+    """Strip characters that would break the .sii pipe-delimited format."""
+    value = _SII_FORBIDDEN.sub(" ", value).strip()
+    return value[:_MAX_FIELD_LEN]
 
 
 def _resolve_lang(language: str, country: str) -> str:
@@ -152,6 +186,9 @@ def _parse_table(table_text: str, country: str) -> list[Station]:
 
         if url is None:
             continue
+        url = _validate_url(url)
+        if url is None:
+            continue
         if name is None:
             name = "Unknown"
         if genre in ("?", ""):
@@ -159,8 +196,8 @@ def _parse_table(table_text: str, country: str) -> list[Station]:
 
         stations.append(Station(
             url=url,
-            name=name,
-            genre=genre,
+            name=_sanitise_field(name),
+            genre=_sanitise_field(genre),
             language=_resolve_lang(language, country),
             bitrate=_parse_bitrate(bitrate_raw),
             country=country,


### PR DESCRIPTION
## Summary

- URL validation in scraper: scheme allowlist (http/https), length cap, netloc check, URL fragment stripping
- Field sanitisation: strips pipe, quote and newline characters from station names and genres to prevent breaking the .sii format
- Strengthened .gitignore with secrets and credential file patterns
- Added SECURITY.md with vulnerability reporting instructions and scope description

## GitHub settings applied
- Dependabot vulnerability alerts enabled
- Dependabot automated security fixes enabled
- master branch protection: no force pushes, no deletions, stale review dismissal
- Delete branch on merge enabled

## Test plan

- [x] Run `python scraper/main.py --no-validate` and confirm 344 stations still parsed
- [x] Confirm URLs with fragments (e.g. `#AddedByRaf_Salvado`) are stripped in output
- [x] Confirm station names/genres containing `|` or `"` are sanitised in output