### PR TITLE
docs: refresh README, security policy, and wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,108 @@
-> This project is maintained with the assistance of [Claude](https://claude.ai) (Anthropic).
-
 # ETS2_RadioFix
 
-A regularly updated `live_streams.sii` file for [Euro Truck Simulator 2](https://eurotrucksimulator2.com/) and [American Truck Simulator](https://americantrucksimulator.com/), sourced from the community [Radio Stations wiki](https://truck-simulator.fandom.com/wiki/Radio_Stations) and the [Radio-Browser](https://www.radio-browser.info/) directory.
+Regularly updated `live_streams.sii` and `live_streams.json` files for [Euro Truck Simulator 2](https://eurotrucksimulator2.com/) and [American Truck Simulator](https://americantrucksimulator.com/), sourced from the community [Radio Stations wiki](https://truck-simulator.fandom.com/wiki/Radio_Stations) and the [Radio-Browser](https://www.radio-browser.info/) directory.
 
 ## Installation
 
-1. Navigate to your ETS2/ATS documents folder — e.g. `C:\Users\[USERNAME]\Documents\Euro Truck Simulator 2\`
-2. Back up your current `live_streams.sii` (rename or copy it elsewhere)
-3. Replace it with the `live_streams.sii` from this repo
+1. Open your ETS2 or ATS documents folder, for example:
+   - `C:\Users\[USERNAME]\Documents\Euro Truck Simulator 2\`
+   - `C:\Users\[USERNAME]\Documents\American Truck Simulator\`
+2. Back up your existing `live_streams.sii`.
+3. Download this repo's latest `live_streams.sii`.
+4. Replace the file in your game documents folder.
+
+The game reads `live_streams.sii` directly. `live_streams.json` is provided for tools, comparisons, and downstream automation.
+
+## Current generated data
+
+Latest committed validation:
+
+- **Live stations:** 1085
+- **Dead streams filtered out:** 213
+- **Country/region sections:** 90 plus `Unknown`
+- **Generated status report:** [STATIONS.md](STATIONS.md)
+- **Dead-stream report:** [VALIDATION.md](VALIDATION.md)
+
+`STATIONS.md` is the source of truth for current per-station status. The summary above should be updated whenever the generated data is refreshed.
 
 ## Scraper
 
-The `scraper/` folder contains a Python CLI that regenerates `live_streams.sii` automatically:
+The `scraper/` folder contains a Python CLI that regenerates the project artifacts:
 
-- Fetches all stations from the Fandom wiki via the MediaWiki API
-- Fetches additional stations from the [Radio-Browser](https://www.radio-browser.info/) API (deduplicated against the Fandom set by stream URL)
-- Validates every stream URL (dead streams are excluded)
-- Outputs fresh `live_streams.sii`, `live_streams.json`, `STATIONS.md`, and `VALIDATION.md` files
+- fetches stations from the Fandom wiki via the MediaWiki API
+- fetches additional stations from Radio-Browser, deduplicated by stream URL
+- validates stream URLs and excludes dead streams by default
+- writes `live_streams.sii`, `live_streams.json`, `STATIONS.md`, and `VALIDATION.md`
 
-**Requirements:** Python 3.10+, no third-party runtime dependencies
+Requirements:
 
-**Usage:**
+- Python 3.10+
+- no third-party runtime dependencies
+
+Usage:
+
 ```bash
-# Full run (scrape + validate, ~1-2 min)
+# Full run: scrape, validate, and regenerate all default artifacts
 python scraper/main.py
 
-# Skip validation
+# Skip validation and write all scraped stations
 python scraper/main.py --no-validate
 
 # Write to custom output paths
-python scraper/main.py --output /tmp/live_streams.sii --json /tmp/live_streams.json
+python scraper/main.py \
+  --output /tmp/live_streams.sii \
+  --json /tmp/live_streams.json \
+  --report /tmp/VALIDATION.md \
+  --stations /tmp/STATIONS.md
 
-# Single country only
+# Single country/region only
 python scraper/main.py --country "United Kingdom"
 
-# Skip the Radio-Browser source (Fandom wiki only)
+# Fandom wiki only, without Radio-Browser additions
 python scraper/main.py --no-radiobrowser
 
-# Pull more/fewer stations from Radio-Browser (default: 1000)
+# Pull more/fewer stations from Radio-Browser, default is 1000
 python scraper/main.py --radiobrowser-limit 2000
 ```
 
-**Last committed validation:** 1085 live stations, 213 dead streams filtered out.
+## Automation and quality checks
 
-See [STATIONS.md](STATIONS.md) for the full per-station live/dead status.
+This repo has two GitHub Actions workflows:
 
-## Current status
+- **CI**: runs on pushes and pull requests; checks Python compilation, unit tests, scraper smoke output, and `live_streams.sii` / `live_streams.json` consistency.
+- **Update radio stations**: runs on the 1st and 15th of each month and can also be triggered manually. It regenerates station data, opens an auto-update PR when files change, and auto-merges once checks pass.
 
-### Countries covered
-* [x] Azerbaijan
-* [x] Belgium
-* [x] Canada
-* [x] Chile
-* [x] Croatia
-* [x] Czechia
-* [x] Denmark
-* [x] France
-* [x] Iceland
-* [x] Latvia
-* [x] New Zealand
-* [x] North Macedonia
-* [x] Philippines
-* [x] Portugal
-* [x] Spain
-* [x] Switzerland
-* [x] Türkiye
-* [x] United Kingdom
-* [x] United States
-* [x] Austria
-* [x] Bulgaria
-* [ ] Estonia
-* [x] Finland
-* [x] Germany
-* [x] Hungary
-* [x] Italy
-* [ ] Lithuania
-* [ ] Luxembourg
-* [x] Netherlands
-* [x] Norway
-* [x] Poland
-* [x] Romania
-* [x] Russia
-* [x] Serbia
-* [x] Slovakia
-* [x] Sweden
-* [x] Ukraine
+Useful local checks:
 
-### Planned features
-* [x] Scrape stations from Fandom wiki automatically
-* [x] Add a second station source (Radio-Browser API)
-* [x] Validate stream URLs and filter dead streams
-* [x] Generate `VALIDATION.md` dead-stream report
-* [x] Scheduled auto-run to keep `live_streams.sii` up to date
-* [x] Auto-open pull request when new stations are found
-* [ ] Add missing countries from the wiki
-* [x] ISO 639-3 language code standardisation across all stations
-* [x] Keep `live_streams.json` in sync with generated `.sii` output
-* [x] Pull request CI for compile, unit, smoke, and generated-artifact checks
+```bash
+python -m compileall -q .
+python -m unittest discover -s tests
+python tests/verify_artifacts.py
+```
+
+Optional development checks used by CI/audits:
+
+```bash
+uvx ruff check .
+uvx bandit -q -r . -x ./.git
+```
+
+## Project status
+
+Completed:
+
+- [x] Scrape stations from the Fandom wiki automatically
+- [x] Add Radio-Browser as a second station source
+- [x] Validate stream URLs and filter dead streams
+- [x] Generate `live_streams.sii`, `live_streams.json`, `STATIONS.md`, and `VALIDATION.md`
+- [x] Scheduled auto-update workflow
+- [x] Auto-open pull requests when generated station data changes
+- [x] Keep `live_streams.json` in sync with generated `.sii` output
+- [x] ISO 639-3 language code standardisation across generated stations
+- [x] Pull request CI for compile, unit, smoke, and generated-artifact checks
+- [x] Basic SSRF hardening for stream validation in CI
+
+Open/ongoing:
+
+- [ ] Continue improving station coverage and upstream source parsing
+- [ ] Retire or replace legacy helper scripts if downstream users no longer need them

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-Only the latest commit on `master` is actively maintained.
+Only the latest commit on the default `master` branch is actively maintained. Generated station data is refreshed by scheduled pull requests.
 
 ## Reporting a vulnerability
 
@@ -11,19 +11,28 @@ If you discover a security vulnerability in this project, please **do not open a
 Instead, report it privately via [GitHub's private vulnerability reporting](https://github.com/MichalJes/ETS2_RadioFix/security/advisories/new).
 
 Please include:
-- A description of the vulnerability
-- Steps to reproduce
-- Potential impact
+
+- a description of the vulnerability
+- steps to reproduce
+- affected file(s), workflow, or generated artifact(s)
+- potential impact
 
 You can expect an acknowledgement within 7 days.
 
 ## Scope
 
-This project scrapes radio station data from the [Truck Simulator Fandom wiki](https://truck-simulator.fandom.com/wiki/Radio_Stations) and the [Radio-Browser](https://www.radio-browser.info/) directory, then writes generated `live_streams.sii`, `live_streams.json`, `STATIONS.md`, and `VALIDATION.md` files. Security considerations include:
+This project scrapes radio station data from the [Truck Simulator Fandom wiki](https://truck-simulator.fandom.com/wiki/Radio_Stations) and the [Radio-Browser](https://www.radio-browser.info/) directory, then writes generated `live_streams.sii`, `live_streams.json`, `STATIONS.md`, and `VALIDATION.md` files.
 
-- **URL injection** — malicious URLs committed to an upstream directory could end up in generated output. The scraper validates all URLs before writing them: only `http` and `https` schemes are allowed, URLs have a length cap, fragments are stripped, malformed URLs are rejected, and local/private/link-local IP literal targets are rejected.
-- **Field injection** — pipe characters, quotes, and newlines are stripped from station names, genres, and country fields to prevent breaking the `.sii` pipe-delimited format.
-- **Validator SSRF hardening** — validation fetches untrusted stream URLs. Before each validation request, the validator rejects unsafe schemes, local/private/link-local/reserved/multicast/unspecified IP targets, hostnames resolving to those ranges, and unsafe redirect targets.
-- **Generated artifact consistency** — CI checks that `live_streams.sii` and `live_streams.json` contain the same stations and contiguous indices.
+Security considerations include:
 
-Known limitation: generated Markdown reports are intended for repository display, not for rendering inside privileged HTML contexts.
+- **Generated file injection** — upstream station names, genres, countries, and URLs are untrusted. Text fields are stripped of pipe characters, quotes, and newlines before they are written to the `.sii` pipe-delimited format.
+- **URL injection** — only `http` and `https` stream URLs are accepted. Malformed URLs, overlong URLs, fragments, SII-breaking characters, and local/private/link-local IP literal targets are rejected before generated output is written.
+- **Validator SSRF hardening** — validation fetches untrusted stream URLs. Before each validation request, the validator rejects unsafe schemes, unsafe IP literals, hostnames resolving to loopback/private/link-local/reserved/multicast/unspecified addresses, mixed safe/unsafe DNS results, and unsafe redirect targets.
+- **Generated artifact consistency** — CI checks that `live_streams.sii` and `live_streams.json` contain the same stations with contiguous indices.
+- **Workflow permissions** — the scheduled update workflow uses repository write permissions so it can open and merge generated-data PRs. Treat changes to `.github/workflows/` as security-sensitive.
+
+## Non-goals and known limitations
+
+- The project validates whether streams are reachable; it does not verify station ownership, licensing, or broadcast content.
+- Generated Markdown reports are intended for GitHub repository display, not for rendering inside privileged HTML contexts.
+- The validator intentionally makes outbound requests to public radio stream hosts. The SSRF protections reduce CI risk but do not make arbitrary URL fetching risk-free.


### PR DESCRIPTION
## Summary
- refresh README to remove stale country checklist and document generated data/current automation
- expand SECURITY.md with workflow, artifact consistency, validator SSRF scope, and limitations
- update the GitHub wiki home page with installation, generated-file, automation, and reporting links

## Verification
- `python -m compileall -q .`
- `python -m unittest discover -s tests`
- `python tests/verify_artifacts.py`
- `uvx ruff check .`
