### PR TITLE
ci: add release automation workflows

### DIFF
--- a/.github/workflows/latest-data-release.yml
+++ b/.github/workflows/latest-data-release.yml
@@ -1,0 +1,85 @@
+name: Latest station data release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  latest-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify generated artifacts
+        run: |
+          python -m compileall -q .
+          python -m unittest discover -s tests
+          python tests/verify_artifacts.py
+
+      - name: Build latest-data assets
+        run: |
+          sha256sum \
+            live_streams.sii \
+            live_streams.json \
+            STATIONS.md \
+            VALIDATION.md > checksums.txt
+
+          cat > release-notes.md <<'EOF'
+          Mutable release containing the latest generated station data from `master`.
+
+          Use the versioned releases for immutable project/tooling snapshots.
+
+          ## Downloads
+          - `live_streams.sii` — drop into the ETS2/ATS documents folder.
+          - `live_streams.json` — JSON station list for tools and downstream consumers.
+          - `STATIONS.md` — generated per-station status report.
+          - `VALIDATION.md` — generated dead-stream report.
+          - `checksums.txt` — SHA256 checksums for release assets.
+          EOF
+
+      - name: Move latest-data tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f latest-data "$GITHUB_SHA"
+          git push origin latest-data --force
+
+      - name: Create or update latest-data release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view latest-data >/dev/null 2>&1; then
+            gh release edit latest-data \
+              --title "Latest station data" \
+              --notes-file release-notes.md \
+              --latest=false
+            gh release upload latest-data \
+              live_streams.sii \
+              live_streams.json \
+              STATIONS.md \
+              VALIDATION.md \
+              checksums.txt \
+              --clobber
+          else
+            gh release create latest-data \
+              live_streams.sii \
+              live_streams.json \
+              STATIONS.md \
+              VALIDATION.md \
+              checksums.txt \
+              --target "$GITHUB_SHA" \
+              --title "Latest station data" \
+              --notes-file release-notes.md \
+              --latest=false
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Versioned release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag, for example v0.4.0"
+        required: true
+        type: string
+      notes:
+        description: "Optional release notes override"
+        required: false
+        type: string
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify release artifacts
+        run: |
+          python -m compileall -q .
+          python -m unittest discover -s tests
+          python tests/verify_artifacts.py
+
+      - name: Build release bundle
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_NOTES: ${{ inputs.notes }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="${INPUT_VERSION}"
+          fi
+          echo "TAG=${TAG}" >> "$GITHUB_ENV"
+
+          bundle="ets2-radiofix-${TAG}.zip"
+          zip -r "$bundle" \
+            LICENSE \
+            README.md \
+            SECURITY.md \
+            VALIDATION.md \
+            STATIONS.md \
+            live_streams.sii \
+            live_streams.json \
+            siiTOjson.py \
+            scraper \
+            tests \
+            .github/workflows/ci.yml \
+            .github/workflows/update-stations.yml \
+            .github/workflows/release.yml \
+            .github/workflows/latest-data-release.yml \
+            -x '*/__pycache__/*' '*.pyc'
+
+          sha256sum \
+            live_streams.sii \
+            live_streams.json \
+            STATIONS.md \
+            VALIDATION.md \
+            "$bundle" > checksums.txt
+
+          if [ -n "${INPUT_NOTES}" ]; then
+            printf '%s\n' "${INPUT_NOTES}" > release-notes.md
+          else
+            cat > release-notes.md <<EOF
+          ## Downloads
+          - \`live_streams.sii\` — drop into the ETS2/ATS documents folder.
+          - \`live_streams.json\` — JSON station list for tools and downstream consumers.
+          - \`STATIONS.md\` — generated per-station status report.
+          - \`VALIDATION.md\` — generated dead-stream report.
+          - \`${bundle}\` — source, scraper, tests, and workflows snapshot.
+          - \`checksums.txt\` — SHA256 checksums for release assets.
+          EOF
+          fi
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" \
+              live_streams.sii \
+              live_streams.json \
+              STATIONS.md \
+              VALIDATION.md \
+              "ets2-radiofix-${TAG}.zip" \
+              checksums.txt \
+              --clobber
+          else
+            gh release create "$TAG" \
+              live_streams.sii \
+              live_streams.json \
+              STATIONS.md \
+              VALIDATION.md \
+              "ets2-radiofix-${TAG}.zip" \
+              checksums.txt \
+              --target "$GITHUB_SHA" \
+              --title "$TAG" \
+              --notes-file release-notes.md
+          fi


### PR DESCRIPTION
## Summary
- add a manual/tag-driven versioned release workflow
- add a manual mutable `latest-data` release workflow
- both workflows verify generated artifacts before publishing release assets

## Verification
- `yamllint` on workflows
- `python -m compileall -q .`
- `python -m unittest discover -s tests`
- `python tests/verify_artifacts.py`
- `uvx ruff check .`
